### PR TITLE
Add universe and multiverse to OTHERMIRROR

### DIFF
--- a/pbuilderrc
+++ b/pbuilderrc
@@ -127,7 +127,14 @@ elif $(echo ${UBUNTU_SUITES[@]} | grep -q $DIST); then
     # Ubuntu configuration
     MIRRORSITE="http://$UBUNTU_MIRROR"
     COMPONENTS="main universe multiverse"
-    OTHERMIRROR="deb http://$UBUNTU_MIRROR $DIST-security main|deb http://$UBUNTU_MIRROR $DIST-updates main"
+    POSSIBLEDISTS=("" "-security" "-updates")
+    for dist in "${POSSIBLEDISTS[@]}"; do
+        for component in ${COMPONENTS}; do
+            OTHERMIRROR="$OTHERMIRROR|deb http://$UBUNTU_MIRROR $DIST${dist} ${component}"
+        done
+    done
+    # Strip leading | symbol
+    OTHERMIRROR=${OTHERMIRROR#?}
     DEBOOTSTRAPOPTS=("--keyring=/etc/apt/trusted.gpg" "--keyring=/usr/share/keyrings/ubuntu-archive-keyring.gpg" "${DEBOOTSTRAPOPTS[@]}")
 
 else


### PR DESCRIPTION
As I've previously discussed in Slack, I've not been able to get the flatpak branch of AppCenter to build with houston/travis due to it not finding the right version of the `libflatpak-dev` dependency. The version I need is in the `universe` repository.

It seems that the `COMPONENTS` variable that includes `universe` and `multiverse` is only used during the base tarball creation, not during the actual package build in chroot. So when the package under test tries to satisfy its dependencies, it only has access to the repositories that were inserted into `OTHERMIRROR`. We can see this from the travis build logs, for example:

During tarball build:
```
Get:1 http://us.archive.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]
Get:2 http://deb.nodesource.com/node_8.x bionic InRelease [4595 B]
Ign:2 http://deb.nodesource.com/node_8.x bionic InRelease
Get:3 http://us.archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
Get:4 http://deb.nodesource.com/node_8.x bionic/main amd64 Packages [765 B]
Get:5 http://ppa.launchpad.net/elementary-os/os-patches/ubuntu bionic InRelease [20.8 kB]
Hit:6 http://us.archive.ubuntu.com/ubuntu bionic InRelease
Get:7 http://us.archive.ubuntu.com/ubuntu bionic-security/main amd64 Packages [334 kB]
Get:8 http://us.archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [598 kB]
Get:9 http://ppa.launchpad.net/elementary-os/stable/ubuntu bionic InRelease [15.4 kB]
Get:10 http://us.archive.ubuntu.com/ubuntu bionic/multiverse amd64 Packages [151 kB]
Get:11 http://us.archive.ubuntu.com/ubuntu bionic/universe amd64 Packages [8570 kB]
Ign:5 http://ppa.launchpad.net/elementary-os/os-patches/ubuntu bionic InRelease
Get:12 http://ppa.launchpad.net/gophers/archive/ubuntu bionic InRelease [15.4 kB]
Ign:9 http://ppa.launchpad.net/elementary-os/stable/ubuntu bionic InRelease
Ign:12 http://ppa.launchpad.net/gophers/archive/ubuntu bionic InRelease
Get:13 http://ppa.launchpad.net/elementary-os/os-patches/ubuntu bionic/main amd64 Packages [29.2 kB]
Get:14 http://ppa.launchpad.net/elementary-os/stable/ubuntu bionic/main amd64 Packages [33.0 kB]
Get:15 http://ppa.launchpad.net/gophers/archive/ubuntu bionic/main amd64 Packages [2020 B]
```

During package build inside chroot:
```
Get:1 http://deb.nodesource.com/node_8.x bionic InRelease [4595 B]
Hit:2 http://us.archive.ubuntu.com/ubuntu bionic-security InRelease
Get:3 http://ppa.launchpad.net/elementary-os/os-patches/ubuntu bionic InRelease [20.8 kB]
Hit:4 http://us.archive.ubuntu.com/ubuntu bionic-updates InRelease
Hit:5 http://us.archive.ubuntu.com/ubuntu bionic InRelease
Ign:1 http://deb.nodesource.com/node_8.x bionic InRelease
Get:6 http://ppa.launchpad.net/elementary-os/stable/ubuntu bionic InRelease [15.4 kB]
Ign:3 http://ppa.launchpad.net/elementary-os/os-patches/ubuntu bionic InRelease
Ign:6 http://ppa.launchpad.net/elementary-os/stable/ubuntu bionic InRelease
Get:7 http://ppa.launchpad.net/gophers/archive/ubuntu bionic InRelease [15.4 kB]
Ign:7 http://ppa.launchpad.net/gophers/archive/ubuntu bionic InRelease
```

The [documentation for pbuilderrc](https://manpages.debian.org/stretch/pbuilder/pbuilderrc.5.en.html) seems to back this up too:

> **OTHERMIRROR:** The deb lines here are the ones that will appear at the top of the sources.list inside the chroot.
> **COMPONENTS:** This option only affects when doing `pbuilder create` or when `--override-config` is specified for `pbuilder update` option.
 