### PR TITLE
Add universe and multiverse to updates and security

### DIFF
--- a/pbuilderrc
+++ b/pbuilderrc
@@ -127,7 +127,7 @@ elif $(echo ${UBUNTU_SUITES[@]} | grep -q $DIST); then
     # Ubuntu configuration
     MIRRORSITE="http://$UBUNTU_MIRROR"
     COMPONENTS="main universe multiverse"
-    OTHERMIRROR="deb http://$UBUNTU_MIRROR $DIST-security main universe multiverse|deb http://$UBUNTU_MIRROR $DIST-updates main universe multiverse"
+    OTHERMIRROR="deb http://$UBUNTU_MIRROR $DIST-security $COMPONENTS|deb http://$UBUNTU_MIRROR $DIST-updates $COMPONENTS"
     DEBOOTSTRAPOPTS=("--keyring=/etc/apt/trusted.gpg" "--keyring=/usr/share/keyrings/ubuntu-archive-keyring.gpg" "${DEBOOTSTRAPOPTS[@]}")
 
 else


### PR DESCRIPTION
Alternative to #8 

`universe` and `multiverse` are enabled in the resulting chroot, but only for `bionic`, not for `bionic-updates` and `bionic-security` like what you'd get on a desktop install.

This doesn't result in any duplicated sources in the list like #8 did and I've tested that it can successfully build the appcenter flatpak branch that I've been having issues with.