### PR TITLE
control: Add dh-python to Dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,7 @@ Homepage: http://elementary.io
 Package: liftoff
 Architecture: any
 Depends: debhelper,
+         dh-python,
 #        ccache,
          debian-archive-keyring,
 #        debian-keyring,


### PR DESCRIPTION
I think this is what's needed to be able to build python packages with liftoff. See an error here:
https://github.com/hezral/inspektor/issues/16

I've verified that this package fixes that error locally.

I have no idea how this liftoff package makes its way onto the Houston (?) servers, but it will need building into a deb and installing there I guess.